### PR TITLE
去除excapeRegExp中的捕获

### DIFF
--- a/avalon.js
+++ b/avalon.js
@@ -415,12 +415,12 @@
         }
         return this
     }
-    var openTag, closeTag, rexpr, rbind, rregexp = /([-.*+?^${}()|[\]\/\\])/g
+    var openTag, closeTag, rexpr, rbind, rregexp = /[-.*+?^${}()|[\]\/\\]/g
 
     function escapeRegExp(target) {
         //http://stevenlevithan.com/regex/xregexp/
         //将字符串安全格式化为正则表达式的源码
-        return (target + "").replace(rregexp, "\\$1")
+        return (target + "").replace(rregexp, "\\$&")
     }
     var plugins = {
         alias: function(val) {


### PR DESCRIPTION
escapeRegExp方法[#L423](https://github.com/RubyLouvre/avalon/blob/master/avalon.js#L423)里面有引用到[xregexp](http://cdnjs.cloudflare.com/ajax/libs/xregexp/2.0.0/xregexp.js)

我去看了源码，里面是没有用到捕获的，这里是否也可由$1改成$&呢？
