### PR TITLE
添加vm.$deleteArray属性，强制跳过扫描

### DIFF
--- a/avalon.js
+++ b/avalon.js
@@ -384,6 +384,13 @@
         var computedProperties = [] //计算属性
         var watchProperties = arguments[2] || {} //强制要监听的属性
         var skipArray = scope.$skipArray //要忽略监控的属性
+        var deleteArray = scope.$deleteArray //要强制删除的属性（不扫描）
+        if (Array.isArray(deleteArray)) {
+            // 添加到全局的skipProperties中去
+            for (var i = 0, name; name = deleteArray[i++]; ) {
+                avalon.Array.ensure(skipProperties, name)
+            }
+        }
         for (var i = 0, name; name = skipProperties[i++]; ) {
             if (typeof name !== "string") {
                 log("warning:$skipArray[" + name + "] must be a string")


### PR DESCRIPTION
我又看了下代码，没找到合适的地方添加一个掉过扫描的配置项，这次在`modelFactory`里面的添加的代码，算是一个hook吧，如果没有`$deleteArray`就不管它。

`强制跳过`的需求来源于我封装的一个库[go-avalon](https://github.com/Archs/go-avalon)，目前遇到的最大的问题就是其中的结构体会产生 issue #393 上面描述的问题

由于[go-avalon](https://github.com/Archs/go-avalon)那边的代码改起来涉及编译器和命名习惯等问题，所以我想能不能在avalon.js上找到一个解决问题的方法，这个pull request的改动有些粗暴，希望司徒大侠多多指正啊
