### PR TITLE
事件回调return false要阻止默认行为与事件传播

### DIFF
--- a/avalon.js
+++ b/avalon.js
@@ -242,7 +242,7 @@
                     fn = hook.deel(el, fn)
                 }
             }
-            var callback = function (){
+            var callback = function (e){
                 var ex = e || fixEvent(window.event);
                 var ret = fn.call(el, ex);
                 if (ret === false) {


### PR DESCRIPTION
1. 博客上的代码有问题
   http://www.cnblogs.com/rubylouvre/archive/2013/05/23/3094591.html
   
   ```
           var ex = fixEvent(e || window.event);
   ```
   
   貌似应该是
               var ex = e || fixEvent(window.event);
2. 有时候为了实现回车就可以提交表单，我更倾向于绑定submit而不是button的click事件
   同时我不希望真的刷新页面提交表单，而是通过ajax进行保存，所以，我需要通过return false来阻止事件传播。
   jquery一直都是这么做的，而且如果你在其他浏览器直接写onsubmit=“xxx”也是一样可以用return false来阻止表单提交。
   这种方式很自然。希望可以支持这个功能。

3.希望可以给ms-on-submit加一个快捷方式ms-submit
