### PR TITLE
require / define 在加载模块时，返回以"/"为起始的模块路径不正确导致不能正确加载模块

### DIFF
--- a/avalon.js
+++ b/avalon.js
@@ -4167,7 +4167,7 @@
                         ret = ret.replace(rdeuce, "")
                     }
                 } else if (tmp === "/") {
-                    ret = parent + url //相对于兄弟路径
+                    ret = url //相对于根路径
                 } else {
                     avalon.error("不符合模块标识规则: " + url)
                 }


### PR DESCRIPTION
require / define 在加载模块时，返回以"/"为起始的模块路径不正确导致不能正确加载模块
