### PR TITLE
修正chrome下，DOMNodeRemoved对于节点的判断

### DIFF
--- a/avalon.js
+++ b/avalon.js
@@ -3075,7 +3075,7 @@
                         elem.addEventListener("DOMNodeRemoved", function(e) {
                             if (e.target === this && !this.msRetain &&
                                     //#441 chrome浏览器对文本域进行Ctrl+V操作，会触发DOMNodeRemoved事件
-                                            (window.chrome ? this.tagName === "INPUT" && e.relatedNode.nodeType === 1 : 1)) {
+                                            (window.chrome ? (this.tagName === "INPUT" ? e.relatedNode.nodeType === 1 : 1) : 1)) {
                                 offTree()
                             }
                         })


### PR DESCRIPTION
现有的方式将导致非input元素的删除，无法执行offTree函数
