### PR TITLE
fixIE8以下处于iframe中的页面的onready检测

### DIFF
--- a/src/18 domReady.js
+++ b/src/18 domReady.js
@@ -37,7 +37,14 @@ if (DOC.readyState === "complete") {
             fireReady()
         }
     })
-    if (root.doScroll) {
+    var isFrame;
+    try{
+        isFrame=window.frameElement!=null//当前页面处于iframe中时,访问frameElement会抛出不允许跨域访问异常
+    }
+    catch(e){
+        isFrame=true
+    }
+    if (root.doScroll&& !isFrame) {//只有不处于iframe时才用doScroll判断,否则可能会不准
         doScrollCheck()
     }
 }


### PR DESCRIPTION
在ie8及以下版本遇到iframe引入的页面中使用avalon,onready的时机不对,导致scan的时候未能解析所有的插值表达式和绑定对象
