### PR TITLE
touchend事件根据条件阻止默认行为,防止点击击穿bug

### DIFF
--- a/src/20 touch.js
+++ b/src/20 touch.js
@@ -108,6 +108,7 @@ new function() {
                 } else {
                     fastclick.focus(element)
                 }
+	            event.preventDefault()
                 W3CFire(element, 'tap')
                 avalon.fastclick.fireEvent(element, "click", event)
                 if (touchProxy.isDoubleTap) {


### PR DESCRIPTION
IOS7.0.4下webview仍有可能出现点击击穿bug,需在touchend中阻止默认
[测试bug页面](http://sandbox.runjs.cn/show/gpnn9vex)
