### PR TITLE
增强camelize参数target判断严谨性

### DIFF
--- a/src/13 dom.js
+++ b/src/13 dom.js
@@ -8,10 +8,11 @@ function hyphen(target) {
 }
 
 function camelize(target) {
-    //转换为驼峰风格
-    if (target.indexOf("-") < 0 && target.indexOf("_") < 0) {
-        return target //提前判断，提高getStyle等的效率
+    //提前判断，提高getStyle等的效率
+    if (!target || target.indexOf("-") < 0 && target.indexOf("_") < 0) {
+        return target
     }
+    //转换为驼峰风格
     return target.replace(/[-_][^-_]/g, function(match) {
         return match.charAt(1).toUpperCase()
     })


### PR DESCRIPTION
target 为 ‘’时，无须转换
意外为undefine时可能出现 indexOf 为定义错误