### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "avalon",
-  "version": "1.4.0",
   "homepage": "https://github.com/RubyLouvre/avalon",
   "descriptions": "a lightweight、high-performance and easy-to-follow javascript MVVM framework",
   "authors": [


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property