### PR TITLE
解决私有化avalon对象后，filter实效问题

### DIFF
--- a/src/17 parser.share.js
+++ b/src/17 parser.share.js
@@ -84,7 +84,7 @@ function parseFilter(val, filters) {
             .replace(rthimLeftParentheses, function () {
                 return '",'
             }) + "]"
-    return  "return avalon.filters.$filter(" + val + ", " + filters + ")"
+    return  "return this.filters.$filter(" + val + ", " + filters + ")"
 }
 
 function parseExpr(code, scopes, data) {
@@ -170,7 +170,10 @@ function parseExpr(code, scopes, data) {
                 "= vvv;\n} "
         try {
             fn = Function.apply(noop, names.concat(_body))
-            data.evaluator = evaluatorPool.put(exprId, fn)
+            data.evaluator = evaluatorPool.put(exprId, function() {
+                //确保可以在编译代码中使用this获取avalon对象
+                return fn.apply(avalon, arguments)
+            })
         } catch (e) {
             log("debug: parse error," + e.message)
         }
@@ -192,7 +195,10 @@ function parseExpr(code, scopes, data) {
     }
     try {
         fn = Function.apply(noop, names.concat("'use strict';\n" + prefix + code))
-        data.evaluator = evaluatorPool.put(exprId, fn)
+        data.evaluator = evaluatorPool.put(exprId, function() {
+            //确保可以在编译代码中使用this获取avalon对象
+            return fn.apply(avalon, arguments)
+        })
     } catch (e) {
         log("debug: parse error," + e.message)
     } finally {


### PR DESCRIPTION
目前，avalon默认注册为window.avalon对象（无论是否使用cmd和and加载均如此），所以filter可以正常使用。

如果我们avalon初始化代码为 var avalon = xxx ;即取消其默认全局注册，此时，filter将出现问题。原因如下：编译系统使用 return avalon.filters.$filter 代码，需要引用window.avalon。