### PR TITLE
缩小编译时将avalon作为this对象的范围

### DIFF
--- a/src/17 parser.share.js
+++ b/src/17 parser.share.js
@@ -161,6 +161,16 @@ function parseExpr(code, scopes, data) {
         }
         code = "\nvar ret" + expose + " = " + code + ";\r\n"
         code += parseFilter("ret" + expose, filters)
+        try {
+            fn = Function.apply(noop, names.concat("'use strict';\n" + prefix + code))
+            data.evaluator = evaluatorPool.put(exprId, function() {
+                return fn.apply(avalon, arguments)//确保可以在编译代码中使用this获取avalon对象
+            })
+        } catch (e) {
+            log("debug: parse error," + e.message)
+        }
+        vars = assigns = names = null //释放内存
+        return
     } else if (dataType === "duplex") { //双工绑定
         var _body = "'use strict';\nreturn function(vvv){\n\t" +
                 prefix +
@@ -170,13 +180,11 @@ function parseExpr(code, scopes, data) {
                 "= vvv;\n} "
         try {
             fn = Function.apply(noop, names.concat(_body))
-            data.evaluator = evaluatorPool.put(exprId, function() {
-                //确保可以在编译代码中使用this获取avalon对象
-                return fn.apply(avalon, arguments)
-            })
+            data.evaluator = evaluatorPool.put(exprId, fn)
         } catch (e) {
             log("debug: parse error," + e.message)
         }
+        vars = assigns = names = null //释放内存
         return
     } else if (dataType === "on") { //事件绑定
         if (code.indexOf("(") === -1) {
@@ -195,15 +203,11 @@ function parseExpr(code, scopes, data) {
     }
     try {
         fn = Function.apply(noop, names.concat("'use strict';\n" + prefix + code))
-        data.evaluator = evaluatorPool.put(exprId, function() {
-            //确保可以在编译代码中使用this获取avalon对象
-            return fn.apply(avalon, arguments)
-        })
+        data.evaluator = evaluatorPool.put(exprId, fn)
     } catch (e) {
         log("debug: parse error," + e.message)
-    } finally {
-        vars = assigns = names = null //释放内存
     }
+    vars = assigns = names = null //释放内存
 }
 function stringifyExpr(code) {
     var hasExpr = rexpr.test(code) //比如ms-class="width{{w}}"的情况


### PR DESCRIPTION
缩小编译时将avalon作为this对象的范围，防止不必要的作用域替换，比如使用原生表单提交可能遇到问题。