### PR TITLE
修改loader不能正确处理url path map之后带query的bug

### DIFF
--- a/avalon.js
+++ b/avalon.js
@@ -5596,7 +5596,11 @@ new function () {// jshint ignore:line
         //5. 还原扩展名，query
         var urlNoQuery = url + ext
         url = urlNoQuery + this.query
-        //6. 处理urlArgs
+/*        urlNoQuery = url.replace(rquery, function (a) {
+            this.query = a
+            return ""
+        })
+*/        //6. 处理urlArgs
         eachIndexArray(id, kernel.urlArgs, function (value) {
             url += (url.indexOf("?") === -1 ? "?" : "&") + value;
         })

--- a/avalon.js
+++ b/avalon.js
@@ -5596,11 +5596,11 @@ new function () {// jshint ignore:line
         //5. 还原扩展名，query
         var urlNoQuery = url + ext
         url = urlNoQuery + this.query
-/*        urlNoQuery = url.replace(rquery, function (a) {
+        urlNoQuery = url.replace(rquery, function (a) {
             this.query = a
             return ""
         })
-*/        //6. 处理urlArgs
+        //6. 处理urlArgs
         eachIndexArray(id, kernel.urlArgs, function (value) {
             url += (url.indexOf("?") === -1 ? "?" : "&") + value;
         })

--- a/avalon.modern.js
+++ b/avalon.modern.js
@@ -4705,6 +4705,10 @@ new function () {// jshint ignore:line
         //5. 还原扩展名，query
         var urlNoQuery = url + ext
         url = urlNoQuery + this.query
+        urlNoQuery = url.replace(rquery, function (a) {
+            this.query = a
+            return ""
+        })
         //6. 处理urlArgs
         eachIndexArray(id, kernel.urlArgs, function (value) {
             url += (url.indexOf("?") === -1 ? "?" : "&") + value;

--- a/src/21 loader.js
+++ b/src/21 loader.js
@@ -560,6 +560,10 @@ new function () {// jshint ignore:line
         //5. 还原扩展名，query
         var urlNoQuery = url + ext
         url = urlNoQuery + this.query
+        urlNoQuery = url.replace(rquery, function (a) {
+            this.query = a
+            return ""
+        })
         //6. 处理urlArgs
         eachIndexArray(id, kernel.urlArgs, function (value) {
             url += (url.indexOf("?") === -1 ? "?" : "&") + value;

--- a/src/21 loader.modern.js
+++ b/src/21 loader.modern.js
@@ -531,6 +531,10 @@ new function () {// jshint ignore:line
         //5. 还原扩展名，query
         var urlNoQuery = url + ext
         url = urlNoQuery + this.query
+        urlNoQuery = url.replace(rquery, function (a) {
+            this.query = a
+            return ""
+        })
         //6. 处理urlArgs
         eachIndexArray(id, kernel.urlArgs, function (value) {
             url += (url.indexOf("?") === -1 ? "?" : "&") + value;


### PR DESCRIPTION
当我们在data-main中指定的脚本文件中动态改变paths config时会导致loader不能正确处理modules的id，使得id有时不带有query，而有时带有query。

config配置如：
```
require.config(
        {
            paths:{
                "foo": "foo?v=bar"
            }
        }
)
```