### PR TITLE
解决repeat内部元素属性暴露的bug

### DIFF
--- a/src/19 directive/repeat.js
+++ b/src/19 directive/repeat.js
@@ -307,7 +307,7 @@ function shimController(data, transation, proxy, fragments, init) {
     var itemName = data.param || "el"
     var valueItem = proxy[itemName], nv
     if (Object(valueItem) === valueItem) {
-        nv = [proxy, valueItem].concat(data.vmodels)
+        nv = [proxy].concat(data.vmodels)
     } else {
         nv = [proxy].concat(data.vmodels)
     }


### PR DESCRIPTION
repeat循环体内的el元素内部属性会暴露在root的vmodel中