### PR TITLE
修复多个计算属性不更新的问题

### DIFF
--- a/src/vmodel/Computed.js
+++ b/src/vmodel/Computed.js
@@ -75,7 +75,7 @@ export var Computed = (function(_super) {
             for (var i in this.deps) {
                 if (this.deps[i].version !== this.depsVersion[i]) {
                     toComputed = true
-                    this.deps[i].version = this.depsVersion[i]
+                    this.depsVersion[i] = this.deps[i].version
                 }
             }
             return toComputed

--- a/test/vmodel/compact.spec.js
+++ b/test/vmodel/compact.spec.js
@@ -291,6 +291,44 @@ describe('Computed', function () {
         expect(vm.c).toBe(25)
         delete avalon.vmodels.computed01
     })
+
+    it('test2', function (done) {
+        var body = document.body
+        var div = document.createElement('div')
+        div.innerHTML = heredoc(function() {
+            /*
+            <div :controller="computed02">
+                <div>{{@b}}</div>
+                <div>{{@c}}</div>
+            </div>
+             */
+        })
+        body.appendChild(div)
+
+        var vm =  avalon.define({
+            $id: 'computed02',
+            $computed: {
+                b: function(){
+                    return this.a + 1
+                },
+                c: function(){
+                    return this.a + 2
+                }
+            },
+            a: 1
+        })
+        avalon.scan(div)
+
+        setTimeout(function () {
+            vm.a = 10
+            expect(vm.b).toBe(11)
+            expect(vm.c).toBe(12)
+
+            body.removeChild(div)
+            delete avalon.vmodels.computed02
+            done()
+        }, 500);
+    })
 })
 
 describe('Action', function () {


### PR DESCRIPTION
判断应该更新计算属性后，原本会更新依赖属性的版本号，但是这样后面依赖这个属性的计算属性就不会更新了，所以改成更新计算属性自己维护的依赖版本号

fixed #1999