### PR TITLE
解决 IE8 html 属性中的中文被转成 unicode 字符串问题

### DIFF
--- a/src/seed/lang.compact.js
+++ b/src/seed/lang.compact.js
@@ -37,7 +37,7 @@ export var compaceQuote = (function() {
     }
 })()
 try {
-    avalon._quote = JSON.stringify
+    avalon._quote = msie <= 8 ? compaceQuote : JSON.stringify;
 } catch (e) {
     /* istanbul ignore next  */
     avalon._quote = compaceQuote


### PR DESCRIPTION
fixed #1974 

使用了 #2020 提出的解决办法。